### PR TITLE
SamsungDoze: fix typo

### DIFF
--- a/doze/AndroidManifest.xml
+++ b/doze/AndroidManifest.xml
@@ -32,7 +32,7 @@
         <activity
             android:name=".TouchscreenGestureSettings"
             android:label="@string/screen_gestures_panel_title"
-            android:theme="@android:style/Theme.Material.Settings">>
+            android:theme="@android:style/Theme.Material.Settings">
             <intent-filter>
                 <action android:name="com.cyanogenmod.action.LAUNCH_TOUCHSCREEN_GESTURE_SETTINGS" />
             </intent-filter>


### PR DESCRIPTION
Change-Id: Id7716387688080b5ce0a99a4d968e210d8eed6f9
